### PR TITLE
Remove duplicate line of code causing build error

### DIFF
--- a/core/java/com/android/internal/statusbar/IStatusBarService.aidl
+++ b/core/java/com/android/internal/statusbar/IStatusBarService.aidl
@@ -95,5 +95,4 @@ interface IStatusBarService
     void toggleFlashlight();
     void toggleNavigationEditor();
     void dispatchNavigationEditorResults(in Intent intent);
-    void startAssist(in Bundle args);
 }


### PR DESCRIPTION
Removes duplicate line of code, "void startAssist(in Bundle args);" which causes a build error in which the duplicate in line 98 attempts to "redefine method startAssist" of the previously defined startAssist in line 92.