### PR TITLE
High Brightness Tile

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -8572,6 +8572,12 @@ public final class Settings {
         public static final String DOUBLE_TAP_TO_WAKE = "double_tap_to_wake";
 
         /**
+         * Controls whether high brightness mode via a QS tile
+         * @hide
+         */
+        public static final String HIGH_BRIGHTNESS_MODE = "high_brightness_mode";
+
+        /**
          * The current assistant component. It could be a voice interaction service,
          * or an activity that handles ACTION_ASSIST, or empty which means using the default
          * handling.

--- a/core/res/res/values/custom_config.xml
+++ b/core/res/res/values/custom_config.xml
@@ -131,4 +131,7 @@
     <!-- Slim recents -->
     <integer name="config_recentDefaultDur">150</integer>
 
+    <!-- High Brightness Mode -->
+    <bool name="config_supportHighBrightness">false</bool>
+
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -195,4 +195,7 @@
     <java-symbol type="color" name="tooltip_text_light" />
     <java-symbol type="color" name="tooltip_text_dark" />
 
+    <!-- High Brightness Mode -->
+    <java-symbol type="bool" name="config_supportHighBrightness" />
+
 </resources>

--- a/packages/SystemUI/res/drawable/ic_qs_brightness_high_off.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_brightness_high_off.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64.000000dp"
+    android:height="64.000000dp"
+    android:viewportWidth="48.000000"
+    android:viewportHeight="48.000000">
+
+    <group
+            android:translateY="48.000000"
+            android:scaleX="0.100000"
+            android:scaleY="-0.100000">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:strokeWidth="1"
+            android:pathData="M222 425 c-13 -29 -21 -31 -48 -10 -28 21 -34 18 -34 -15 0 -28 -3 -30 -35 -30 -33
+0 -34 -1 -25 -26 15 -37 13 -41 -22 -48 l-31 -6 23 -25 23 -25 -23 -25 -23 -25 32
+-11 c33 -12 34 -17 16 -62 -7 -16 -4 -18 29 -12 35 7 36 6 36 -24 0 -35 10 -38 44
+-16 21 14 23 14 34 -10 6 -14 16 -25 22 -25 6 0 16 11 22 25 11 24 13 24 34 10 34
+-22 44 -19 44 16 0 30 1 31 36 24 33 -6 36 -4 29 12 -18 45 -17 50 16 62 l32 11
+-23 25 -23 25 23 25 23 25 -31 6 c-35 7 -37 11 -22 48 9 25 8 26 -25 26 -32 0 -35
+2 -35 30 0 33 -6 36 -34 15 -27 -21 -35 -19 -48 10 -6 14 -14 25 -18 25 -4 0 -12
+-11 -18 -25z m94 -81 c28 -19 54 -72 54 -111 0 -62 -64 -123 -130 -123 -66 0 -130
+61 -130 123 0 59 42 116 95 130 29 8 84 -2 111 -19z" />
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:strokeWidth="1"
+            android:pathData="M177 320 c-38 -30 -52 -80 -33 -123 15 -37 59 -67 96 -67 37 0 81 30 96 67 29 68
+-21 143 -96 143 -22 0 -48 -8 -63 -20z" />
+    </group>
+</vector>

--- a/packages/SystemUI/res/drawable/ic_qs_brightness_high_on.xml
+++ b/packages/SystemUI/res/drawable/ic_qs_brightness_high_on.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2014 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64.000000dp"
+    android:height="64.000000dp"
+    android:viewportWidth="48.000000"
+    android:viewportHeight="48.000000">
+
+    <group
+            android:translateY="48.000000"
+            android:scaleX="0.100000"
+            android:scaleY="-0.100000">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:strokeWidth="1"
+            android:pathData="M222 425 c-13 -29 -21 -31 -48 -10 -28 21 -34 18 -34 -15 0 -28 -3 -30 -35 -30 -33
+0 -34 -1 -25 -26 15 -37 13 -41 -22 -48 l-31 -6 23 -25 23 -25 -23 -25 -23 -25 32
+-11 c33 -12 34 -17 16 -62 -7 -16 -4 -18 29 -12 35 7 36 6 36 -24 0 -35 10 -38 44
+-16 21 14 23 14 34 -10 6 -14 16 -25 22 -25 6 0 16 11 22 25 11 24 13 24 34 10 34
+-22 44 -19 44 16 0 30 1 31 36 24 33 -6 36 -4 29 12 -18 45 -17 50 16 62 l32 11
+-23 25 -23 25 23 25 23 25 -31 6 c-35 7 -37 11 -22 48 9 25 8 26 -25 26 -32 0 -35
+2 -35 30 0 33 -6 36 -34 15 -27 -21 -35 -19 -48 10 -6 14 -14 25 -18 25 -4 0 -12
+-11 -18 -25z m-22 -130 c0 -34 1 -35 40 -35 39 0 40 1 40 35 0 28 4 35 20 35 19 0
+20 -7 20 -90 0 -83 -1 -90 -20 -90 -17 0 -20 7 -20 40 l0 40 -40 0 -40 0 0 -40 c0
+-33 -3 -40 -20 -40 -19 0 -20 7 -20 90 0 83 1 90 20 90 16 0 20 -7 20 -35z" />
+    </group>
+</vector>

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -112,7 +112,7 @@
 
     <!-- Tiles native to System UI. Order should match "quick_settings_tiles_default" -->
     <string name="quick_settings_tiles_stock" translatable="false">
-        wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,work,cast,night,lte,caffeine,reboot,pip,screenshot,adb_network,sound,heads_up,screenrecord,hwkeys,volume,sync,expanded_desktop,usb_tether,weather,cpuinfo,compass,always_on_display,assist,smartpixels,music,theme,immersive,soundsearch
+        wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,work,cast,night,lte,caffeine,reboot,pip,screenshot,adb_network,sound,heads_up,screenrecord,hwkeys,volume,sync,expanded_desktop,usb_tether,weather,cpuinfo,compass,always_on_display,assist,smartpixels,music,theme,immersive,soundsearch,,high_brightness
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/res/values/custom_strings.xml
+++ b/packages/SystemUI/res/values/custom_strings.xml
@@ -347,4 +347,7 @@
     <!-- Sound search QS Tile -->
     <string name="quick_settings_sound_search">Sound search</string>
 
+    <!-- High Brightness Mode Tile -->
+    <string name="quick_settings_high_brightness">High brightness</string>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
@@ -41,6 +41,7 @@ import com.android.systemui.qs.tiles.GoogleAssistTile;
 import com.android.systemui.qs.tiles.GoogleNowTile;
 import com.android.systemui.qs.tiles.GoogleVoiceAssistTile;
 import com.android.systemui.qs.tiles.HeadsUpTile;
+import com.android.systemui.qs.tiles.HighBrightnessTile;
 import com.android.systemui.qs.tiles.HotspotTile;
 import com.android.systemui.qs.tiles.HWKeysTile;
 import com.android.systemui.qs.tiles.ImmersiveTile;
@@ -121,6 +122,7 @@ public class QSFactoryImpl implements QSFactory {
         else if (tileSpec.equals("theme")) return new ThemeTile(mHost);
         else if (tileSpec.equals("immersive")) return new ImmersiveTile(mHost);
         else if (tileSpec.equals("soundsearch")) return new SoundSearchTIle(mHost);
+        else if (tileSpec.equals("high_brightness")) return new HighBrightnessTile(mHost);
         // Intent tiles.
         else if (tileSpec.startsWith(IntentTile.PREFIX)) return IntentTile.create(mHost, tileSpec);
         else if (tileSpec.startsWith(CustomTile.PREFIX)) return CustomTile.create(mHost, tileSpec);

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/HighBrightnessTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/HighBrightnessTile.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.qs.tiles;
+
+import android.content.Intent;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.service.quicksettings.Tile;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.systemui.qs.QSHost;
+import com.android.systemui.plugins.qs.QSTile.BooleanState;
+import com.android.systemui.qs.tileimpl.QSTileImpl;
+import com.android.systemui.R;
+
+public class HighBrightnessTile extends QSTileImpl<BooleanState> {
+
+    public HighBrightnessTile(QSHost host) {
+        super(host);
+    }
+
+    @Override
+    public BooleanState newTileState() {
+        return new BooleanState();
+    }
+
+    private ContentObserver mObserver = new ContentObserver(mHandler) {
+        @Override
+        public void onChange(boolean selfChange, Uri uri) {
+            refreshState();
+        }
+    };
+
+    @Override
+    public void handleSetListening(boolean listening) {
+        if (listening) {
+            mContext.getContentResolver().registerContentObserver(
+                    Settings.Secure.getUriFor(Settings.Secure.HIGH_BRIGHTNESS_MODE),
+                    false, mObserver);
+        } else {
+            mContext.getContentResolver().unregisterContentObserver(mObserver);
+        }
+    }
+
+    @Override
+    public void handleClick() {
+        toggleState();
+        refreshState();
+    }
+
+    @Override
+    public void handleLongClick() {
+
+    }
+
+    @Override
+    public CharSequence getTileLabel() {
+        return mContext.getString(R.string.quick_settings_high_brightness);
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.LIQUID;
+    }
+
+    @Override
+    public Intent getLongClickIntent() {
+        return null;
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        boolean highBrightness = Settings.Secure.getIntForUser(mContext.getContentResolver(),
+                Settings.Secure.HIGH_BRIGHTNESS_MODE, 0,
+                UserHandle.USER_CURRENT) != 0;
+
+        state.label = mContext.getString(R.string.quick_settings_high_brightness);
+        state.icon = highBrightness
+                ? ResourceIcon.get(R.drawable.ic_qs_brightness_high_on)
+                : ResourceIcon.get(R.drawable.ic_qs_brightness_high_off);
+        state.state = highBrightness ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE;
+    }
+
+    protected void toggleState() {
+        boolean highBrightness = Settings.Secure.getIntForUser(mContext.getContentResolver(),
+                Settings.Secure.HIGH_BRIGHTNESS_MODE, 0,
+                UserHandle.USER_CURRENT) != 0;
+        Settings.Secure.putIntForUser(mContext.getContentResolver(),
+                Settings.Secure.HIGH_BRIGHTNESS_MODE, highBrightness ? 0 : 1,
+                UserHandle.USER_CURRENT);
+    }
+}

--- a/packages/overlays/SysuiDarkThemeOverlay/res/drawable/autofill_dataset_picker_background.xml
+++ b/packages/overlays/SysuiDarkThemeOverlay/res/drawable/autofill_dataset_picker_background.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2017 The Android Open Source Project
-
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-
           http://www.apache.org/licenses/LICENSE-2.0
-
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -225,6 +225,12 @@ public final class PowerManagerService extends SystemService
     /** If turning screen on takes more than this long, we show a warning on logcat. */
     private static final int SCREEN_ON_LATENCY_WARNING_MS = 200;
 
+    // Power feature to Enable High Brightness Mode
+    private static final int POWER_FEATURE_HIGH_BRIGHTNESS_MODE = 1;
+
+    // Default setting for High Brightness Mode.
+    private static final int DEFAULT_HIGH_BRIGHTNESS_MODE = 0;
+
     /** Constants for {@link #shutdownOrRebootInternal} */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({HALT_MODE_SHUTDOWN, HALT_MODE_REBOOT, HALT_MODE_REBOOT_SAFE_MODE})
@@ -458,6 +464,9 @@ public final class PowerManagerService extends SystemService
     // Whether device supports double tap to wake.
     private boolean mSupportsDoubleTapWakeConfig;
 
+    // Whether device supports High Brightness Mode.
+    private boolean mSupportsHighBrightnessModeConfig;
+
     // The screen off timeout setting value in milliseconds.
     private int mScreenOffTimeoutSetting;
 
@@ -600,6 +609,9 @@ public final class PowerManagerService extends SystemService
     // True if double tap to wake is enabled
     private boolean mDoubleTapWakeEnabled;
 
+    // True if High Brightness Mode is enabled
+    private boolean mHighBrightnessModeEnabled;
+
     private final ArrayList<PowerManagerInternal.LowPowerModeListener> mLowPowerModeListeners
             = new ArrayList<PowerManagerInternal.LowPowerModeListener>();
 
@@ -721,6 +733,7 @@ public final class PowerManagerService extends SystemService
             nativeSetAutoSuspend(false);
             nativeSetInteractive(true);
             nativeSetFeature(POWER_FEATURE_DOUBLE_TAP_TO_WAKE, 0);
+            nativeSetFeature(POWER_FEATURE_HIGH_BRIGHTNESS_MODE,0);
         }
     }
 
@@ -900,6 +913,9 @@ public final class PowerManagerService extends SystemService
         resolver.registerContentObserver(Settings.Secure.getUriFor(
                 Settings.System.PROXIMITY_ON_WAKE),
                 false, mSettingsObserver, UserHandle.USER_ALL);
+        resolver.registerContentObserver(Settings.Secure.getUriFor(
+                Settings.Secure.HIGH_BRIGHTNESS_MODE),
+                false, mSettingsObserver, UserHandle.USER_ALL);
 
         IVrManager vrManager = (IVrManager) getBinderService(Context.VR_SERVICE);
         if (vrManager != null) {
@@ -979,6 +995,8 @@ public final class PowerManagerService extends SystemService
             mProximityWakeLock = ((PowerManager) mContext.getSystemService(Context.POWER_SERVICE))
                     .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "ProximityWakeLock");
         }
+        mSupportsHighBrightnessModeConfig = resources.getBoolean(
+                com.android.internal.R.bool.config_supportHighBrightness);
     }
 
     private void updateSettingsLocked() {
@@ -1029,6 +1047,16 @@ public final class PowerManagerService extends SystemService
         final String retailDemoValue = UserManager.isDeviceInDemoMode(mContext) ? "1" : "0";
         if (!retailDemoValue.equals(SystemProperties.get(SYSTEM_PROPERTY_RETAIL_DEMO_ENABLED))) {
             SystemProperties.set(SYSTEM_PROPERTY_RETAIL_DEMO_ENABLED, retailDemoValue);
+        }
+
+        if (mSupportsHighBrightnessModeConfig) {
+            boolean highBrightnessModeEnabled = Settings.Secure.getIntForUser(resolver,
+                    Settings.Secure.HIGH_BRIGHTNESS_MODE, DEFAULT_HIGH_BRIGHTNESS_MODE,
+                            UserHandle.USER_CURRENT) != 0;
+            if (highBrightnessModeEnabled != mHighBrightnessModeEnabled) {
+                mHighBrightnessModeEnabled = highBrightnessModeEnabled;
+                nativeSetFeature(POWER_FEATURE_HIGH_BRIGHTNESS_MODE, mHighBrightnessModeEnabled ? 1 : 0);
+            }
         }
 
         final int oldScreenBrightnessSetting = getCurrentBrightnessSettingLocked();
@@ -2565,6 +2593,10 @@ public final class PowerManagerService extends SystemService
             screenAutoBrightnessAdjustment = Math.max(Math.min(
                     screenAutoBrightnessAdjustment, 1.0f), -1.0f);
 
+            if (mSupportsHighBrightnessModeConfig && mHighBrightnessModeEnabled) {
+                nativeSetFeature(POWER_FEATURE_HIGH_BRIGHTNESS_MODE, 1);
+            }
+
             // Update display power request.
             mDisplayPowerRequest.screenBrightness = screenBrightness;
             mDisplayPowerRequest.screenAutoBrightnessAdjustment =
@@ -3554,6 +3586,7 @@ public final class PowerManagerService extends SystemService
             pw.println("  mScreenBrightnessForVrSetting=" + mScreenBrightnessForVrSetting);
             pw.println("  mDoubleTapWakeEnabled=" + mDoubleTapWakeEnabled);
             pw.println("  mIsVrModeEnabled=" + mIsVrModeEnabled);
+            pw.println("  mHighBrightnessModeEnabled=" + mHighBrightnessModeEnabled);
 
             final int sleepTimeout = getSleepTimeoutLocked();
             final int screenOffTimeout = getScreenOffTimeoutLocked(sleepTimeout);


### PR DESCRIPTION
-------
ezio84: adapt tile to O
remove toast and panel collapsing from the tile
fix device tree power.c setFeature call
default set to disabled

--------

This commit will allow controlling of a kernel's High Brightness
mode by toggling the setting: Settings.Secure.HIGH_BRIGHTNESS_MODE

This mode allows for a brightness beyond 100% brightness from within
the rom. It is very handy for high brightness scenarios, ie: direct
sunlight.

Depends on support in the device tree and du vendor overlay. On
supported devices, this will already typically exist in the kernel.

NOTE:
While kernel based High Brightness Mode is active it will override
any manual/automatic brightness settings from the rom.

Change-Id: I147e3fcc331a5881328f43262a69e348ad253567

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Signed-off-by: VenkatVishalV <venkatvishal124@gmail.com>