### PR TITLE
Enabled corner padding

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/RoundedCorners.java
+++ b/packages/SystemUI/src/com/android/systemui/RoundedCorners.java
@@ -54,9 +54,9 @@ public class RoundedCorners extends SystemUI implements Tunable {
     private View mOverlay;
     private View mBottomOverlay;
     private float mDensity;
-    /*private TunablePadding mQsPadding;
+    private TunablePadding mQsPadding;
     private TunablePadding mStatusBarPadding;
-    private TunablePadding mNavBarPadding;*/
+    private TunablePadding mNavBarPadding;
 
     @Override
     public void start() {


### PR DESCRIPTION
I'm not sure why these values are commented out but I believe they are needed to support rounded corner displays (like the OP6, for example.)