### PR TITLE
Camera: allow camera to use power key as shutter

### DIFF
--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -1117,6 +1117,10 @@ public abstract class Window {
     }
 
     private void setPrivateFlags(int flags, int mask) {
+        if ((flags & mask & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0) {
+            mContext.enforceCallingOrSelfPermission("android.permission.PREVENT_POWER_KEY",
+                    "No permission to prevent power key");
+        }
         final WindowManager.LayoutParams attrs = getAttributes();
         attrs.privateFlags = (attrs.privateFlags & ~mask) | (flags & mask);
         dispatchWindowAttributesChanged(attrs);

--- a/core/java/android/view/WindowManager.java
+++ b/core/java/android/view/WindowManager.java
@@ -1419,6 +1419,12 @@ public interface WindowManager extends ViewManager {
         public static final int FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS = 0x80000000;
 
         /**
+         * Window flag: Overrides default power key behavior
+         * @hide
+         */
+        public static final int PRIVATE_FLAG_PREVENT_POWER_KEY = 0x20000000;
+
+        /**
          * Various behavioral options/flags.  Default is none.
          *
          * @see #FLAG_ALLOW_LOCK_WHILE_SCREEN_ON

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -3991,12 +3991,18 @@
     <permission android:name="android.permission.DISABLE_HIDDEN_API_CHECKS"
                 android:protectionLevel="signature" />
 
-    <!-- Allows an application to restart the SystemUI process.-->
+   <!-- Allows an application to restart the SystemUI process.-->
     <permission android:name="android.permission.RESTART_UI"
         android:label="@string/permlab_restartUI"
         android:description="@string/permdesc_restartUI"
         android:protectionLevel="signature" />
+   <!-- LineageOS additions -->
 
+    <!-- Allows an application to override the power key action
+         @hide <p>Not for use by third-party applications.
+    -->
+    <permission android:name="android.permission.PREVENT_POWER_KEY"
+                android:protectionLevel="signature|privileged" />
     <application android:process="system"
                  android:persistent="true"
                  android:hasCode="false"

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -7216,6 +7216,12 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             }
 
             case KeyEvent.KEYCODE_POWER: {
+                if (mTopFullscreenOpaqueWindowState != null
+                        && (mTopFullscreenOpaqueWindowState.getAttrs().privateFlags
+                                & WindowManager.LayoutParams.PRIVATE_FLAG_PREVENT_POWER_KEY) != 0
+                        && mScreenOnFully) {
+                    return result;
+                }
                 // Any activity on the power button stops the accessibility shortcut
                 cancelPendingAccessibilityShortcutAction();
                 result &= ~ACTION_PASS_TO_USER;


### PR DESCRIPTION
Provides a way for an app to take control of the power key.
Used by the camera to make the power key control the shutter.

Change-Id: I85a1e1761199f4604672be42a3a5005227f5451a
(cherry picked from commit 15661444ae1faea831218f0c936b756de2f0698b)

Prevent power key capture when screen is off

The ability for an activity to capture the power key, which was
added to support power key as shutter in the camera, should only
allow the capture when the screen is on. Otherwise, if an activity
that captures the power key is to the front when the device turns
off, the user will be unable to turn it back on.

Change-Id: Ib119d6914ec72554b404c1cc17eef3a932d5d402

PhoneWindowManager: add mTopFullscreenOpaqueWindowState null check to fix exception

Discovered through extensive testing with double press power for camera combined
with long press power for torch (though these features are not required to
trigger the issue), lack of null check here can occasionally result in either of:

1) screen is off, power press will NOT turn the screen on (needs to be woken
   via fingerprint, power cable connect or leave device for a minute or
   so and it will eventually wake on power press again).
OR
2) screen is on, power press will not turn the screen off

It requires pressing power shortly after screen off or screen on at just
the right time to trigger.  Issue is reproducible on angler.

E InputManager-JNI: An exception was thrown by callback 'interceptKeyBeforeQueueing'.
E InputManager-JNI: java.lang.NullPointerException: Attempt to invoke interface method
 'android.view.WindowManager$LayoutParams android.view.WindowManagerPolicy$WindowState.getAttrs()'
on a null object reference
E InputManager-JNI:      at com.android.server.policy.PhoneWindowManager.interceptKeyBeforeQueueing(PhoneWindowManager.java:6647)
E InputManager-JNI:      at com.android.server.wm.InputMonitor.interceptKeyBeforeQueueing(InputMonitor.java:399)
E InputManager-JNI:      at com.android.server.input.InputManagerService.interceptKeyBeforeQueueing(InputManagerService.java:1979)

Change-Id: I77d094130d58b152fdfa515f53661543976b33bf
(cherry picked from commit dc0c974e6a904dc637b8c49ed67d34f17fea5532)

core: Update PREVENT_POWER_KEY permission for M

Change-Id: Iac053a317314fad08545c8dc411ad44f977b8f3e

WindowManager: Add clearPrivateFlags

Change-Id: I0b51a52bf26f3566e74063e22f5c1b187c74b525