### PR TITLE
Camera: Force HAL1 for predefined package list.

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -574,8 +574,21 @@ public class Camera {
             mEventHandler = null;
         }
 
-        return native_setup(new WeakReference<Camera>(this), cameraId, halVersion,
-                ActivityThread.currentOpPackageName());
+        String packageName = ActivityThread.currentOpPackageName();
+
+        // Force HAL1 if the package name falls in this bucket
+        String packageList = SystemProperties.get("vendor.camera.hal1.packagelist", "");
+        if (packageList.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageList);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    halVersion = CAMERA_HAL_API_VERSION_1_0;
+                    break;
+                }
+            }
+        }
+        return native_setup(new WeakReference<Camera>(this), cameraId, halVersion, packageName);
     }
 
     private int cameraInitNormal(int cameraId) {


### PR DESCRIPTION
Force HAL1 for some of the popular apps to optimize power savings.
Use the following setprop to add any package : vendor.camera.hal1.packagelist

Change-Id: I14321c63516178dead54f04e2f6828e10225ed9e
Signed-off-by: DennySPB <dennyspb@gmail.com>