### PR TITLE
Avoid a rogue SystemUI crash

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/CollapsedStatusBarFragment.java
@@ -443,6 +443,8 @@ public class CollapsedStatusBarFragment extends Fragment implements CommandQueue
     }
 
     public void updateLogoSettings(boolean animate) {
+        if (getContext() == null)
+            return;
         mShowLogo = Settings.System.getIntForUser(
             getContext().getContentResolver(), Settings.System.STATUS_BAR_LOGO, 0,
             UserHandle.USER_CURRENT) == 1;


### PR DESCRIPTION
A nullpointer exception occured when opening LiquidLounge>StatusBar or LiquidLounge>Notifications for the first time after a clean flash. This is a stopgap fix until we figure out the real reason behind the exception.

Signed-off-by: sayan7848 <sayan7848@gmail.com>